### PR TITLE
[droidvdec] Bugfix for raise condition jollamobile/jb49044

### DIFF
--- a/gst/droidcodec/gstdroidvdec.c
+++ b/gst/droidcodec/gstdroidvdec.c
@@ -1143,7 +1143,9 @@ gst_droidvdec_finish (GstVideoDecoder * decoder)
   GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
   /* Now we wait for the codec to signal EOS */
   g_cond_wait (&dec->state_cond, &dec->state_lock);
+  g_mutex_unlock (&dec->state_lock);
   GST_VIDEO_DECODER_STREAM_LOCK (decoder);
+  g_mutex_lock (&dec->state_lock);
   GST_LOG_OBJECT (dec, "acquired stream lock");
 
   /* We drained the codec. Better to recreate it. */


### PR DESCRIPTION
Deadlock happens:

1st thread:
gst_droidvdec_finish (decoder=decoder@entry=0xb82ca250) at gstdroidvdec.c:1146 
trying to lock GST_VIDEO_DECODER_STREAM_LOCK (decoder) while dec->state_lock is locked.

2nd thread:
gst_droidvdec_handle_frame (decoder=0xb82ca250, frame=0xae06e498) at gstdroidvdec.c:1201
trying to lock dec->state_lock in GST_VIDEO_DECODER_STREAM_LOCK (decoder) context